### PR TITLE
add gstreamer for chroma plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=builder-mp3val /tmp/out/*/*.apk /pkgs/
 ENV UID=1000
 ENV GID=1000
 RUN apk add --no-cache --upgrade --virtual=build-dependencies build-base libffi-dev openssl-dev python3-dev jpeg-dev libpng-dev zlib-dev jpeg-dev && \
-    apk add --no-cache --upgrade sudo python3 libev chromaprint ffmpeg && \
+    apk add --no-cache --upgrade sudo python3 libev chromaprint ffmpeg gstreamer && \
     apk add --no-cache --allow-untrusted /pkgs/* && \
     python3 -m ensurepip && \
     pip3 install --no-cache-dir . --requirement requirements-docker.txt && \


### PR DESCRIPTION
Hi,

I have the `chroma` plugin enabled in my beets config. It seems that this image is intended to use `chroma` because `pyacoustid` and `chromaprint` are included, but according to the [beets chroma plugin documentation](https://beets.readthedocs.io/en/stable/plugins/chroma.html) it needs `gstreamer` installed, so i added that to the `Dockerfile`.

Without `gstreamer` i often got the message `chroma: fingerprinting of b'/downloads/....' failed: audio could not be decoded`, it's gone after installing `gstreamer`.